### PR TITLE
Add benchmarking version label to the containers during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ The following example illustrates the principle based on a `DummyOptimizer` and 
 💡 You can check the location of the log files of your singularity instances with `singularity instance list -l`.
 ⚠ When creating recipes, take care that the paths are correct. In particular, check relative vs. absolute paths (e.g. benchmarking/... ❌ vs /benchmarking/... ✔).
 
+💡 You can check the creation time and benchmarking version of a container with `singularity inspect <container>`. 
+   To check the versions of the installed packages, you can use `singularity exec <container> pip freeze`.
+
 #### Noctua2 Setup Before Compilation
 
 Include the following lines in your `~/.bashrc`:

--- a/container_recipes/benchmarks/DUMMY_Problem/DUMMY_Problem.recipe
+++ b/container_recipes/benchmarks/DUMMY_Problem/DUMMY_Problem.recipe
@@ -31,8 +31,12 @@ From: continuumio/anaconda3
     pip install -r /benchmarking/requirements.txt
     pip install ../benchmarking
     pip install -r /benchmarking/container_recipes/general/general_requirements_container_problem.txt
-    
+
+    # log benchmarking version
+    BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+    echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
     # benchmark-specific commands go here
     pip install -r /benchmarking/container_recipes/benchmarks/DUMMY_Problem/DUMMY_Problem_requirements.txt
-    
+
     echo "Successfully installed all features"

--- a/container_recipes/benchmarks/bbob/bbob_container.recipe
+++ b/container_recipes/benchmarks/bbob/bbob_container.recipe
@@ -29,6 +29,10 @@ From: python:3.10-slim
     pip install ../benchmarking
     pip install -r /benchmarking/container_recipes/general/general_requirements_container_problem.txt
 
+    # log benchmarking version
+    BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+    echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
     # benchmark-specific commands go here
     pip install -r /benchmarking/container_recipes/benchmarks/bbob/bbob_requirements.txt
 

--- a/container_recipes/benchmarks/hpob/hpob_container.recipe
+++ b/container_recipes/benchmarks/hpob/hpob_container.recipe
@@ -29,6 +29,10 @@ From: python:3.10-slim
     pip install ../benchmarking
     pip install -r /benchmarking/container_recipes/general/general_requirements_container_problem.txt
 
+   # log benchmarking version
+   BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+   echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
    # benchmark-specific commands go here
    pip install -r benchmarking/container_recipes/benchmarks/hpob/hpob_requirements.txt
 

--- a/container_recipes/benchmarks/yahpo/yahpo_container.recipe
+++ b/container_recipes/benchmarks/yahpo/yahpo_container.recipe
@@ -32,6 +32,10 @@ From: continuumio/anaconda3
    pip install ../benchmarking
    pip install -r /benchmarking/container_recipes/general/general_requirements_container_problem.txt
 
+   # log benchmarking version
+   BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+   echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
    # benchmark-specific commands go here
    pip install -r /benchmarking/container_recipes/benchmarks/yahpo/yahpo_requirements.txt
    cd /benchmarking/smacbenchmarking

--- a/container_recipes/general/runner.recipe
+++ b/container_recipes/general/runner.recipe
@@ -19,6 +19,10 @@ From: python:3.10-slim
     pip install ../benchmarking
     pip install -r /benchmarking/container_recipes/general/general_requirements_container_runner.txt
 
+    # log benchmarking version
+    BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+    echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
     echo "Successfully installed all features"
 
 %runscript

--- a/container_recipes/optimizers/DUMMY_Optimizer/DUMMY_Optimizer.recipe
+++ b/container_recipes/optimizers/DUMMY_Optimizer/DUMMY_Optimizer.recipe
@@ -25,6 +25,10 @@ From: continuumio/anaconda3
    pip install ../benchmarking
    pip install -r /benchmarking/container_recipes/general/general_requirements_container_optimizer.txt
 
+   # log benchmarking version
+   BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+   echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
    # benchmark-specific commands go here
    pip install -r benchmarking/container_recipes/optimizers/DUMMY_Optimizer/DUMMY_Optimizer_requirements.txt
 

--- a/container_recipes/optimizers/randomsearch/randomsearch.recipe
+++ b/container_recipes/optimizers/randomsearch/randomsearch.recipe
@@ -24,4 +24,8 @@ From: python:3.10-slim
     pip install ../benchmarking
     pip install -r /benchmarking/container_recipes/general/general_requirements_container_optimizer.txt
 
+    # log benchmarking version
+    BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+    echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
     echo "Successfully installed all features"

--- a/container_recipes/optimizers/smac14/smac14.recipe
+++ b/container_recipes/optimizers/smac14/smac14.recipe
@@ -25,6 +25,10 @@ From: python:3.10-slim
    pip install ../benchmarking
    pip install -r /benchmarking/container_recipes/general/general_requirements_container_optimizer.txt
 
+   # log benchmarking version
+   BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+   echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
    # benchmark-specific commands go here
    pip install -r benchmarking/container_recipes/optimizers/smac14/smac14_requirements.txt
 

--- a/container_recipes/optimizers/smac20/smac20.recipe
+++ b/container_recipes/optimizers/smac20/smac20.recipe
@@ -24,6 +24,10 @@ From: continuumio/miniconda3
     pip install /benchmarking
     pip install -r /benchmarking/container_recipes/general/general_requirements_container_optimizer.txt
 
+    # log benchmarking version
+    BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+    echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
     # benchmark-specific commands go here
     pip install -r /benchmarking/container_recipes/optimizers/smac20/smac20_requirements.txt
 

--- a/container_recipes/optimizers/synetune/synetune_container.recipe
+++ b/container_recipes/optimizers/synetune/synetune_container.recipe
@@ -29,6 +29,10 @@ From: continuumio/miniconda3
    pip install ../benchmarking
    pip install -r /benchmarking/container_recipes/general/general_requirements_container_optimizer.txt
 
+   # log benchmarking version
+   BENCHMARKING_VERSION=$(python -c "import smacbenchmarking; print(smacbenchmarking.version)")
+   echo "benchmarking_version $BENCHMARKING_VERSION" >> "$SINGULARITY_LABELS"
+
    # optimizer-specific commands go here
    pip install -r benchmarking/container_recipes/optimizers/synetune/synetune_requirements.txt
 


### PR DESCRIPTION
- Add smacbenchmarking version to container labels
- Container build data is included in keys already