### PR TITLE
Adapt Nevergrad to MO

### DIFF
--- a/carps/configs/optimizer/nevergrad/ES.yaml
+++ b/carps/configs/optimizer/nevergrad/ES.yaml
@@ -1,0 +1,16 @@
+# @package _global_
+optimizer_id: Nevergrad-ES
+optimizer_container_id: Nevergrad
+optimizer:
+  _target_: carps.optimizers.nevergrad.NevergradOptimizer
+  _partial_: true
+  nevergrad_cfg:
+    optimizer_name: "EvolutionStrategy"
+    seed: ${seed}
+  optimizer_cfg:
+    recombination_ratio: 0
+    popsize: 40
+    offsprings: null
+    only_offsprings: false
+    ranker: nsga2
+    

--- a/carps/optimizers/nevergrad.py
+++ b/carps/optimizers/nevergrad.py
@@ -39,6 +39,7 @@ ext_opts = {
     "CMA-ES": ng.optimization.optimizerlib.ParametrizedCMA,
     "bayes_opt": ng.optimization.optimizerlib.ParametrizedBO,
     "DE": ng.families.DifferentialEvolution,
+    "EvolutionStrategy": ng.families.EvolutionStrategy,
 }
 
 
@@ -97,7 +98,7 @@ class NevergradOptimizer(Optimizer):
 
         self._solver: NGOptimizer | ConfNGOptimizer | None = None
         self.counter = 0
-        self.history: dict[str, Tuple[ng.p.Parameter, float | None]] = {}
+        self.history: dict[str, Tuple[ng.p.Parameter, float | list[float]| None]] = {}
 
     def convert_configspace(self, configspace: ConfigurationSpace) -> ng.p.Parameter:
         """Convert ConfigSpace configuration space to search space from optimizer.
@@ -216,10 +217,6 @@ class NevergradOptimizer(Optimizer):
         assert unique_name in self.history
         assert self._solver is not None
 
-        if isinstance(trial_value.cost, list):
-            raise NotImplementedError(
-                "Multiobjective optimization not yet implemented for Nevergrad!"
-            )
         self.history[unique_name] = (self.history[unique_name][0], trial_value.cost)
 
         self.solver.tell(
@@ -238,19 +235,32 @@ class NevergradOptimizer(Optimizer):
         incumbent = None
         cost = None
         unique_name = None
-        for name, value in self.history.items():
-            if incumbent is None or value[1] < cost:
-                incumbent = value[0].value
-                cost = value[1]
-                unique_name = name
-        if cost is None:
-            raise ValueError(
-                f"Tried to get Incumbent without calling tell() for config {incumbent}!"
+        if self.task.n_objectives > 1:
+            configs = self.solver.pareto_front()
+            costs = [param.losses.tolist() for param in configs]
+            trial_info = [self.convert_to_trial(
+                config = Configuration(
+                    self.configspace, 
+                    values=config.value
+                )
+            ) for config in configs]
+            trial_value = [TrialValue(cost=cost) for cost in costs]
+            incumbent_tuple = list(zip(trial_info, trial_value))
+        else: 
+            for name, value in self.history.items():
+                if incumbent is None or value[1] < cost:
+                    incumbent = value[0].value
+                    cost = value[1]
+                    unique_name = name
+            if cost is None:
+                raise ValueError(
+                    f"Tried to get Incumbent without calling tell() for config {incumbent}!"
+                )
+            trial_info = self.convert_to_trial(
+                config=Configuration(self.configspace, values=incumbent),
+                name=unique_name,
+                seed=self.nevergrad_cfg.seed,
             )
-        trial_info = self.convert_to_trial(
-            config=Configuration(self.configspace, values=incumbent),
-            name=unique_name,
-            seed=self.nevergrad_cfg.seed,
-        )
-        trial_value = TrialValue(cost=cost)
-        return (trial_info, trial_value)
+            trial_value = TrialValue(cost=cost)
+            incumbent_tuple = (trial_info, trial_value)
+        return incumbent_tuple


### PR DESCRIPTION
Title: Tried to adapt `Nevergrad` to MultiObjective in CARP-S

[//]: <> (This is also a comment.)
[//]: <> (Here begins the actual PR body)

## Checks made

Nevergrad DE and ES were ran on the following benchmark:
* Pymoo set of MO problems

## New Features added

* EvolutionaryStrategy from (here)[https://github.com/facebookresearch/nevergrad/blob/main/nevergrad/optimization/es.py#L93] as `ES.yaml`
* Previously added Nevergrad-DE also works on MO problems