### PR TITLE
Adapt mfpbench to MO and update mfpbench SO configs

### DIFF
--- a/carps/configs/problem/MFPBench/SO/mfh/mfh3_bad.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh3_bad.yaml
@@ -1,10 +1,12 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh3_terrible
+problem_id: mfpbench/mfh/mfh3_bad
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh
-  benchmark: mfh3_terrible
+  metric:
+  - value
+  benchmark: mfh3_bad
   budget_type: z
   prior: null
   perturb_prior: null
@@ -12,14 +14,15 @@ problem:
     bias: null
     noise: null
 task:
-  n_trials: 100
+  n_trials: 90
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - value
   is_multifidelity: true
   fidelity_type: z
-  min_budget: 3
+  min_budget: 1
   max_budget: 100
   has_constraints: null
   domain: synthetic

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh3_bad.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh3_bad.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh3_bad
+problem_id: mfpbench/SO/mfh/mfh3_bad
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh3_good.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh3_good.yaml
@@ -1,35 +1,39 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/pd1/translatewmt_xformer_64
+problem_id: mfpbench/mfh/mfh3_good
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
-  benchmark_name: pd1
-  benchmark: translatewmt_xformer_64
-  budget_type: epoch
+  benchmark_name: mfh
+  metric:
+  - value
+  benchmark: mfh3_good
+  budget_type: z
   prior: null
   perturb_prior: null
   benchmark_kwargs:
-    datadir: ./data
+    bias: null
+    noise: null
 task:
-  n_trials: 100
+  n_trials: 90
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - value
   is_multifidelity: true
-  fidelity_type: epoch
+  fidelity_type: z
   min_budget: 1
-  max_budget: 19
+  max_budget: 100
   has_constraints: null
-  domain: DL
+  domain: synthetic
   objective_function_approximation: surrogate
   has_virtual_time: true
   deterministic: true
-  dimensions: 4
+  dimensions: 3
   search_space_n_categoricals: 0
   search_space_n_ordinals: 0
   search_space_n_integers: 0
-  search_space_n_floats: 4
+  search_space_n_floats: 3
   search_space_has_conditionals: false
   search_space_has_forbiddens: false
   search_space_has_priors: false

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh3_good.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh3_good.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh3_good
+problem_id: mfpbench/SO/mfh/mfh3_good
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh3_moderate.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh3_moderate.yaml
@@ -1,35 +1,39 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/pd1/lm1b_transformer_2048
+problem_id: mfpbench/mfh/mfh3_moderate
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
-  benchmark_name: pd1
-  benchmark: lm1b_transformer_2048
-  budget_type: epoch
+  benchmark_name: mfh
+  metric:
+  - value
+  benchmark: mfh3_moderate
+  budget_type: z
   prior: null
   perturb_prior: null
   benchmark_kwargs:
-    datadir: ./data
+    bias: null
+    noise: null
 task:
-  n_trials: 100
+  n_trials: 90
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - value
   is_multifidelity: true
-  fidelity_type: epoch
+  fidelity_type: z
   min_budget: 1
-  max_budget: 74
+  max_budget: 100
   has_constraints: null
-  domain: DL
+  domain: synthetic
   objective_function_approximation: surrogate
   has_virtual_time: true
   deterministic: true
-  dimensions: 4
+  dimensions: 3
   search_space_n_categoricals: 0
   search_space_n_ordinals: 0
   search_space_n_integers: 0
-  search_space_n_floats: 4
+  search_space_n_floats: 3
   search_space_has_conditionals: false
   search_space_has_forbiddens: false
   search_space_has_priors: false

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh3_moderate.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh3_moderate.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh3_moderate
+problem_id: mfpbench/SO/mfh/mfh3_moderate
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh3_terrible.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh3_terrible.yaml
@@ -1,10 +1,12 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh6_moderate
+problem_id: mfpbench/mfh/mfh3_terrible
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh
-  benchmark: mfh6_moderate
+  metric:
+  - value
+  benchmark: mfh3_terrible
   budget_type: z
   prior: null
   perturb_prior: null
@@ -12,25 +14,26 @@ problem:
     bias: null
     noise: null
 task:
-  n_trials: 100
+  n_trials: 90
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - value
   is_multifidelity: true
   fidelity_type: z
-  min_budget: 3
+  min_budget: 1
   max_budget: 100
   has_constraints: null
   domain: synthetic
   objective_function_approximation: surrogate
   has_virtual_time: true
   deterministic: true
-  dimensions: 6
+  dimensions: 3
   search_space_n_categoricals: 0
   search_space_n_ordinals: 0
   search_space_n_integers: 0
-  search_space_n_floats: 6
+  search_space_n_floats: 3
   search_space_has_conditionals: false
   search_space_has_forbiddens: false
   search_space_has_priors: false

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh3_terrible.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh3_terrible.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh3_terrible
+problem_id: mfpbench/SO/mfh/mfh3_terrible
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh6_bad.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh6_bad.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh6_bad
+problem_id: mfpbench/SO/mfh/mfh6_bad
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh6_bad.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh6_bad.yaml
@@ -1,10 +1,12 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh6_terrible
+problem_id: mfpbench/mfh/mfh6_bad
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh
-  benchmark: mfh6_terrible
+  metric:
+  - value
+  benchmark: mfh6_bad
   budget_type: z
   prior: null
   perturb_prior: null
@@ -12,14 +14,15 @@ problem:
     bias: null
     noise: null
 task:
-  n_trials: 100
+  n_trials: 118
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - value
   is_multifidelity: true
   fidelity_type: z
-  min_budget: 3
+  min_budget: 1
   max_budget: 100
   has_constraints: null
   domain: synthetic

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh6_good.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh6_good.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh6_good
+problem_id: mfpbench/SO/mfh/mfh6_good
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh6_good.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh6_good.yaml
@@ -1,35 +1,39 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/pd1/imagenet_resnet_512
+problem_id: mfpbench/mfh/mfh6_good
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
-  benchmark_name: pd1
-  benchmark: imagenet_resnet_512
-  budget_type: epoch
+  benchmark_name: mfh
+  metric:
+  - value
+  benchmark: mfh6_good
+  budget_type: z
   prior: null
   perturb_prior: null
   benchmark_kwargs:
-    datadir: ./data
+    bias: null
+    noise: null
 task:
-  n_trials: 100
+  n_trials: 118
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - value
   is_multifidelity: true
-  fidelity_type: epoch
-  min_budget: 3
-  max_budget: 99
+  fidelity_type: z
+  min_budget: 1
+  max_budget: 100
   has_constraints: null
-  domain: DL
+  domain: synthetic
   objective_function_approximation: surrogate
   has_virtual_time: true
   deterministic: true
-  dimensions: 4
+  dimensions: 6
   search_space_n_categoricals: 0
   search_space_n_ordinals: 0
   search_space_n_integers: 0
-  search_space_n_floats: 4
+  search_space_n_floats: 6
   search_space_has_conditionals: false
   search_space_has_forbiddens: false
   search_space_has_priors: false

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh6_moderate.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh6_moderate.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh6_moderate
+problem_id: mfpbench/SO/mfh/mfh6_moderate
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh6_moderate.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh6_moderate.yaml
@@ -1,10 +1,12 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh6_good
+problem_id: mfpbench/mfh/mfh6_moderate
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh
-  benchmark: mfh6_good
+  metric:
+  - value
+  benchmark: mfh6_moderate
   budget_type: z
   prior: null
   perturb_prior: null
@@ -12,14 +14,15 @@ problem:
     bias: null
     noise: null
 task:
-  n_trials: 100
+  n_trials: 118
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - value
   is_multifidelity: true
   fidelity_type: z
-  min_budget: 3
+  min_budget: 1
   max_budget: 100
   has_constraints: null
   domain: synthetic

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh6_terrible.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh6_terrible.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh6_terrible
+problem_id: mfpbench/SO/mfh/mfh6_terrible
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh

--- a/carps/configs/problem/MFPBench/SO/mfh/mfh6_terrible.yaml
+++ b/carps/configs/problem/MFPBench/SO/mfh/mfh6_terrible.yaml
@@ -1,10 +1,12 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh3_good
+problem_id: mfpbench/mfh/mfh6_terrible
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: mfh
-  benchmark: mfh3_good
+  metric:
+  - value
+  benchmark: mfh6_terrible
   budget_type: z
   prior: null
   perturb_prior: null
@@ -12,25 +14,26 @@ problem:
     bias: null
     noise: null
 task:
-  n_trials: 100
+  n_trials: 118
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - value
   is_multifidelity: true
   fidelity_type: z
-  min_budget: 3
+  min_budget: 1
   max_budget: 100
   has_constraints: null
   domain: synthetic
   objective_function_approximation: surrogate
   has_virtual_time: true
   deterministic: true
-  dimensions: 3
+  dimensions: 6
   search_space_n_categoricals: 0
   search_space_n_ordinals: 0
   search_space_n_integers: 0
-  search_space_n_floats: 3
+  search_space_n_floats: 6
   search_space_has_conditionals: false
   search_space_has_forbiddens: false
   search_space_has_priors: false

--- a/carps/configs/problem/MFPBench/SO/pd1/cifar100_wideresnet_2048.yaml
+++ b/carps/configs/problem/MFPBench/SO/pd1/cifar100_wideresnet_2048.yaml
@@ -1,36 +1,38 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh3_moderate
+problem_id: mfpbench/SO/pd1/cifar100_wideresnet_2048
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
-  benchmark_name: mfh
-  benchmark: mfh3_moderate
-  budget_type: z
+  benchmark_name: pd1
+  metric:
+  - valid_error_rate
+  benchmark: cifar100_wideresnet_2048
+  budget_type: epoch
   prior: null
   perturb_prior: null
   benchmark_kwargs:
-    bias: null
-    noise: null
+    datadir: ../HPO_Suite/data
 task:
   n_trials: 100
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - valid_error_rate
   is_multifidelity: true
-  fidelity_type: z
-  min_budget: 3
-  max_budget: 100
+  fidelity_type: epoch
+  min_budget: 1
+  max_budget: 199
   has_constraints: null
-  domain: synthetic
+  domain: DL
   objective_function_approximation: surrogate
   has_virtual_time: true
   deterministic: true
-  dimensions: 3
+  dimensions: 4
   search_space_n_categoricals: 0
   search_space_n_ordinals: 0
   search_space_n_integers: 0
-  search_space_n_floats: 3
+  search_space_n_floats: 4
   search_space_has_conditionals: false
   search_space_has_forbiddens: false
   search_space_has_priors: false

--- a/carps/configs/problem/MFPBench/SO/pd1/cifar100_wideresnet_2048.yaml
+++ b/carps/configs/problem/MFPBench/SO/pd1/cifar100_wideresnet_2048.yaml
@@ -11,7 +11,7 @@ problem:
   prior: null
   perturb_prior: null
   benchmark_kwargs:
-    datadir: ../HPO_Suite/data
+    datadir: ./data
 task:
   n_trials: 100
   time_budget: null

--- a/carps/configs/problem/MFPBench/SO/pd1/imagenet_resnet_512.yaml
+++ b/carps/configs/problem/MFPBench/SO/pd1/imagenet_resnet_512.yaml
@@ -1,36 +1,38 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh3_bad
+problem_id: mfpbench/SO/pd1/imagenet_resnet_512
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
-  benchmark_name: mfh
-  benchmark: mfh3_bad
-  budget_type: z
+  benchmark_name: pd1
+  metric:
+  - valid_error_rate
+  benchmark: imagenet_resnet_512
+  budget_type: epoch
   prior: null
   perturb_prior: null
   benchmark_kwargs:
-    bias: null
-    noise: null
+    datadir: ./data
 task:
   n_trials: 100
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - valid_error_rate
   is_multifidelity: true
-  fidelity_type: z
-  min_budget: 3
-  max_budget: 100
+  fidelity_type: epoch
+  min_budget: 1
+  max_budget: 99
   has_constraints: null
-  domain: synthetic
+  domain: DL
   objective_function_approximation: surrogate
   has_virtual_time: true
   deterministic: true
-  dimensions: 3
+  dimensions: 4
   search_space_n_categoricals: 0
   search_space_n_ordinals: 0
   search_space_n_integers: 0
-  search_space_n_floats: 3
+  search_space_n_floats: 4
   search_space_has_conditionals: false
   search_space_has_forbiddens: false
   search_space_has_priors: false

--- a/carps/configs/problem/MFPBench/SO/pd1/lm1b_transformer_2048.yaml
+++ b/carps/configs/problem/MFPBench/SO/pd1/lm1b_transformer_2048.yaml
@@ -1,10 +1,12 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/pd1/cifar100_wideresnet_2048
+problem_id: mfpbench/SO/pd1/lm1b_transformer_2048
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
   benchmark_name: pd1
-  benchmark: cifar100_wideresnet_2048
+  metric:
+  - valid_error_rate
+  benchmark: lm1b_transformer_2048
   budget_type: epoch
   prior: null
   perturb_prior: null
@@ -15,11 +17,12 @@ task:
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - valid_error_rate
   is_multifidelity: true
   fidelity_type: epoch
-  min_budget: 45
-  max_budget: 199
+  min_budget: 1
+  max_budget: 74
   has_constraints: null
   domain: DL
   objective_function_approximation: surrogate

--- a/carps/configs/problem/MFPBench/SO/pd1/translatewmt_xformer_64.yaml
+++ b/carps/configs/problem/MFPBench/SO/pd1/translatewmt_xformer_64.yaml
@@ -1,36 +1,38 @@
 # @package _global_
 benchmark_id: MFPBench
-problem_id: mfpbench/mfh/mfh6_bad
+problem_id: mfpbench/SO/pd1/translatewmt_xformer_64
 problem:
   _target_: carps.benchmarks.mfpbench.MFPBenchProblem
-  benchmark_name: mfh
-  benchmark: mfh6_bad
-  budget_type: z
+  benchmark_name: pd1
+  metric:
+  - valid_error_rate
+  benchmark: translatewmt_xformer_64
+  budget_type: epoch
   prior: null
   perturb_prior: null
   benchmark_kwargs:
-    bias: null
-    noise: null
+    datadir: ./data
 task:
   n_trials: 100
   time_budget: null
   n_workers: 1
   n_objectives: 1
-  objectives: null
+  objectives:
+  - valid_error_rate
   is_multifidelity: true
-  fidelity_type: z
-  min_budget: 3
-  max_budget: 100
+  fidelity_type: epoch
+  min_budget: 1
+  max_budget: 19
   has_constraints: null
-  domain: synthetic
+  domain: DL
   objective_function_approximation: surrogate
   has_virtual_time: true
   deterministic: true
-  dimensions: 6
+  dimensions: 4
   search_space_n_categoricals: 0
   search_space_n_ordinals: 0
   search_space_n_integers: 0
-  search_space_n_floats: 6
+  search_space_n_floats: 4
   search_space_has_conditionals: false
   search_space_has_forbiddens: false
   search_space_has_priors: false


### PR DESCRIPTION
Title: Adapting `mfpbench` to Multiobjective in CARP-S

[//]: <> (This is also a comment.)
[//]: <> (Here begins the actual PR body)

## Features:
* Adapts the mfpbench benchmark suite to the MO case.
* Updated configs of mfpbench/SO (`n_trials`, `min_budget`, `problem.metric`, `task.objectives`)

## Checks made

This benchmark was ran on the following optimizers:
* smac20 multifidelity
* dehb
* SyneTune ASHA, BOHB