### PR TITLE
Added MO for HPOBench

### DIFF
--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_10101.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_10101.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/10101
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 10101
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_12.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_12.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/12
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 12
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146212.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146212.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/146212
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 146212
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146606.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146606.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/146606
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 146606
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146818.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146818.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/146818
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 146818
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146821.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146821.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/146821
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 146821
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146822.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_146822.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/146822
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 146822
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_14965.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_14965.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/14965
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 14965
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_167119.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_167119.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/167119
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 167119
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_167120.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_167120.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/167120
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 167120
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_168911.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_168911.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/168911
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 168911
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_168912.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_168912.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/168912
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 168912
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_3.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_3.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/3
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 3
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_31.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_31.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/31
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 31
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_3917.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_3917.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/3917
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 3917
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_53.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_53.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/53
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 53
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_7592.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_7592.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/7592
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 7592
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_9952.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_9952.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/9952
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 9952
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_9977.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_9977.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/9977
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 9977
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_9981.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_lr_9981.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/lr/9981
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: lr
+  task_id: 9981
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_10101.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_10101.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/nn/10101
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: nn
+  task_id: 10101
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 110
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 5
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 5
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_146818.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_146818.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/nn/146818
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: nn
+  task_id: 146818
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 110
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 5
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 5
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_146821.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_146821.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/nn/146821
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: nn
+  task_id: 146821
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 110
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 5
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 5
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_146822.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_146822.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/nn/146822
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: nn
+  task_id: 146822
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 110
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 5
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 5
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_31.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_31.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/nn/31
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: nn
+  task_id: 31
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 110
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 5
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 5
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_3917.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_3917.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/nn/3917
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: nn
+  task_id: 3917
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 110
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 5
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 5
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_53.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_53.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/nn/53
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: nn
+  task_id: 53
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 110
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 5
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 5
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_9952.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_nn_9952.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/nn/9952
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: nn
+  task_id: 9952
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 110
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 5
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 5
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_10101.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_10101.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/10101
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 10101
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_12.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_12.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/12
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 12
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146212.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146212.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/146212
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 146212
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146606.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146606.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/146606
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 146606
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146818.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146818.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/146818
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 146818
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146821.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146821.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/146821
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 146821
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146822.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_146822.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/146822
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 146822
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_14965.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_14965.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/14965
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 14965
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_167119.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_167119.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/167119
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 167119
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_167120.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_167120.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/167120
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 167120
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_168911.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_168911.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/168911
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 168911
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_168912.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_168912.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/168912
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 168912
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_3.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_3.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/3
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 3
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_31.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_31.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/31
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 31
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_3917.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_3917.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/3917
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 3917
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_53.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_53.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/53
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 53
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_7592.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_7592.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/7592
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 7592
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_9952.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_9952.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/9952
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 9952
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_9977.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_9977.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/9977
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 9977
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_9981.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_rf_9981.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/rf/9981
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: rf
+  task_id: 9981
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_10101.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_10101.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/10101
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 10101
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_12.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_12.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/12
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 12
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146212.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146212.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/146212
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 146212
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146606.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146606.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/146606
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 146606
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146818.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146818.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/146818
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 146818
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146821.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146821.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/146821
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 146821
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146822.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_146822.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/146822
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 146822
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_14965.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_14965.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/14965
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 14965
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_167119.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_167119.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/167119
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 167119
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_167120.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_167120.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/167120
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 167120
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_168911.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_168911.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/168911
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 168911
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_168912.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_168912.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/168912
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 168912
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_3.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_3.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/3
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 3
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_31.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_31.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/31
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 31
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_3917.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_3917.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/3917
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 3917
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_53.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_53.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/53
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 53
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_7592.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_7592.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/7592
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 7592
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_9952.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_9952.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/9952
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 9952
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_9977.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_9977.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/9977
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 9977
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_9981.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_svm_9981.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/svm/9981
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: svm
+  task_id: 9981
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 77
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 2
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 2
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_10101.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_10101.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/10101
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 10101
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_12.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_12.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/12
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 12
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146212.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146212.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/146212
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 146212
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146606.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146606.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/146606
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 146606
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146818.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146818.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/146818
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 146818
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146821.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146821.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/146821
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 146821
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146822.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_146822.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/146822
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 146822
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_14965.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_14965.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/14965
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 14965
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_167119.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_167119.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/167119
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 167119
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_167120.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_167120.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/167120
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 167120
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_168911.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_168911.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/168911
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 168911
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_168912.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_168912.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/168912
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 168912
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_3.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_3.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/3
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 3
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_31.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_31.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/31
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 31
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_3917.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_3917.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/3917
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 3917
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_53.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_53.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/53
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 53
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_7592.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_7592.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/7592
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 7592
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_9952.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_9952.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/9952
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 9952
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_9977.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_9977.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/9977
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 9977
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false

--- a/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_9981.yaml
+++ b/carps/configs/problem/HPOBench/MO/tab/cfg_ml_xgboost_9981.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+benchmark_id: HPOBench
+problem_id: hpobench/MO/tab/ml/xgboost/9981
+problem:
+  _target_: carps.benchmarks.hpo_bench.HPOBenchProblem
+  model: xgboost
+  task_id: 9981
+  metric:
+  - function_value
+  - cost
+  budget_type: null
+  seed: ${seed}
+task:
+  n_trials: 100
+  time_budget: null
+  n_workers: 1
+  n_objectives: 2
+  objectives:
+  - function_value
+  - cost
+  is_multifidelity: false
+  fidelity_type: null
+  min_budget: null
+  max_budget: null
+  has_constraints: false
+  domain: ML
+  objective_function_approximation: tabular
+  has_virtual_time: false
+  deterministic: false
+  dimensions: 4
+  search_space_n_categoricals: 0
+  search_space_n_ordinals: 4
+  search_space_n_integers: 0
+  search_space_n_floats: 0
+  search_space_has_conditionals: false
+  search_space_has_forbiddens: false
+  search_space_has_priors: false


### PR DESCRIPTION
Title: Adding Multiobjective to `HPOBench` in CARP-S as part of #96 

[//]: <> (This is also a comment.)
[//]: <> (Here begins the actual PR body)

## Checks made

This optimizer/benchmark was ran on the following benchmark/optimizer:
* smac20 multiobjective
* Synetune BO_MO_LS, BO_MO_RS, MOREA
* Nevergrad DE and ES (nsga2)

## Features

The key features of this addition includes:

* All existing `carps/.../HPOBench/blackbox/tab` configs were adapted to MO with the objectives `function_value` and `cost`.

## Note

[//]: <> (Any explicit consideration that had to be made, any limitations, or the exact scope, and possible future extensions)

I made a local change to my HPOBench installation at `HPOBench/setup.py` to support Python versions `<3.11`. This was `<=3.10` previously. Tests were performed using Python version `3.10.14`