### PR TITLE
docs: update install instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ publish: clean-build build
 	$(PYTHON) -m twine upload --repository testpypi ${DIST}/*
 	@echo
 	@echo "Test with the following:"
-	@echo "* Create a new virtual environment to install the uplaoded distribution into"
+	@echo "* Create a new virtual environment to install the uploaded distribution into"
 	@echo "* Run the following:"
 	@echo "--- pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ ${PACKAGE_NAME}==${VERSION}"
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ clean-build:
 
 # Build a distribution in ./dist
 build:
-    $(PYTHON) -m pip install build
-    $(PYTHON) -m build --sdist
+	$(PYTHON) -m pip install build
+	$(PYTHON) -m build --sdist
 
 # Publish to testpypi
 # Will echo the commands to actually publish to be run to publish to actual PyPi

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ For more details on CARP-S, please have a look at the
 [documentation](https://AutoML.github.io/CARP-S/latest/).
 
 ## Installation
+
+### Installation from PyPI
+
 To install CARP-S, you can simply use `pip`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ dummy,dehb,hebo,nevergrad,optuna,skopt,smac,smac14,synetune
 Please note that installing all requirements for all benchmarks and optimizers in a single 
 environment will not be possible due to conflicting dependencies.
 
+Furthermore, for HPOBench, you need to install the following additional requirements:
+```bash
+pip install git+https://github.com/automl/HPOBench.git --ignore-requires-python
+pip install scikit-learn==0.24.2 --no-build-isolation
+```
+
 ### Installation from Source
 
 If you want to install from source, you can clone the repository and install CARP-S via:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ dummy,dehb,hebo,nevergrad,optuna,skopt,smac,smac14,synetune
 Please note that installing all requirements for all benchmarks and optimizers in a single 
 environment will not be possible due to conflicting dependencies.
 
+### Installation from Source
+
 If you want to install from source, you can clone the repository and install CARP-S via:
 
 ```bash
@@ -64,6 +66,26 @@ If you want to install CARP-S for development, you can use the following command
 ```bash
 make install-dev
 ```
+
+### Additional Data Downloads
+
+For some benchmarks, it is additionally necessary to download data, 
+such as surrogate models, in order to run the benchmark: 
+
+-   For HPOB, you can download the surrogate benchmarks with
+    ```bash
+    bash container_recipes/benchmarks/HPOB/download_data.sh
+    ```
+
+-   For MFPBench, you can download the surrogate benchmarks with
+    ```bash
+    bash container_recipes/benchmarks/MFPBench/download_data.sh
+    ```
+
+-   For YAHPO, you can download the required surrogate benchmarks and meta-data with
+    ```bash
+    bash container_recipes/benchmarks/YAHPO/prepare_yahpo.sh
+    ```
 
 ## Minimal Example
 Once the requirements for both an optimizer and a benchmark, e.g. `SMAC2.0` and `BBOB`, are installed, you can run

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install carps[smac,bbob]
 
 All possible install options for benchmarks are:
 ```bash
-dummy,bhob,hpob,hpobench,mfpbench,pymoo,yahpoo
+dummy,bhob,hpob,hpobench,mfpbench,pymoo,yahpo
 ```
 
 All possible install options for optimizers are:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install carps[smac,bbob]
 
 All possible install options for benchmarks are:
 ```bash
-dummy,bhob,hpob,hpobench,mfpbench,pymoo,yahpo
+dummy,bhob,hpob,mfpbench,pymoo,yahpo
 ```
 
 All possible install options for optimizers are:
@@ -45,12 +45,6 @@ dummy,dehb,hebo,nevergrad,optuna,skopt,smac,smac14,synetune
 
 Please note that installing all requirements for all benchmarks and optimizers in a single 
 environment will not be possible due to conflicting dependencies.
-
-Furthermore, for HPOBench, you need to install the following additional requirements:
-```bash
-pip install git+https://github.com/automl/HPOBench.git --ignore-requires-python
-pip install scikit-learn==0.24.2 --no-build-isolation
-```
 
 ### Installation from Source
 
@@ -76,9 +70,14 @@ If you want to install CARP-S for development, you can use the following command
 make install-dev
 ```
 
-### Additional Data Downloads
+### Additional Steps for Benchmarks
 
-For some benchmarks, it is additionally necessary to download data, 
+For HPOBench, it is necessary to install the requirements via:
+```bash
+bash container_recipes/benchmarks/HPOBench/install_HPOBench.sh
+```
+
+For some benchmarks, it is necessary to download data, 
 such as surrogate models, in order to run the benchmark: 
 
 -   For HPOB, you can download the surrogate benchmarks with

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ pip install carps[smac,bbob]
 
 All possible install options for benchmarks are:
 ```bash
-dummy,bhob,hpob,hpobench,mfpbench,pymoo,yahpo
+dummy,bhob,hpob,mfpbench,pymoo,yahpo
 ```
 
 All possible install options for optimizers are:
@@ -30,12 +30,6 @@ dummy,dehb,hebo,nevergrad,optuna,skopt,smac,smac14,synetune
 
 Please note that installing all requirements for all benchmarks and optimizers in a single 
 environment will not be possible due to conflicting dependencies.
-
-Furthermore, for HPOBench, you need to install the following additional requirements:
-```bash
-pip install git+https://github.com/automl/HPOBench.git --ignore-requires-python
-pip install scikit-learn==0.24.2 --no-build-isolation
-```
 
 ### Installation from Source
 
@@ -61,9 +55,14 @@ If you want to install CARP-S for development, you can use the following command
 make install-dev
 ```
 
-### Additional Data Downloads
+### Additional Steps for Benchmarks
 
-For some benchmarks, it is additionally necessary to download data, 
+For HPOBench, it is necessary to install the requirements via:
+```bash
+bash container_recipes/benchmarks/HPOBench/install_HPOBench.sh
+```
+
+For some benchmarks, it is necessary to download data, 
 such as surrogate models, in order to run the benchmark: 
 
 -   For HPOB, you can download the surrogate benchmarks with

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,6 +31,12 @@ dummy,dehb,hebo,nevergrad,optuna,skopt,smac,smac14,synetune
 Please note that installing all requirements for all benchmarks and optimizers in a single 
 environment will not be possible due to conflicting dependencies.
 
+Furthermore, for HPOBench, you need to install the following additional requirements:
+```bash
+pip install git+https://github.com/automl/HPOBench.git --ignore-requires-python
+pip install scikit-learn==0.24.2 --no-build-isolation
+```
+
 ### Installation from Source
 
 If you want to install from source, you can clone the repository and install CARP-S via:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ pip install carps[smac,bbob]
 
 All possible install options for benchmarks are:
 ```bash
-dummy,bhob,hpob,hpobench,mfpbench,pymoo,yahpoo
+dummy,bhob,hpob,hpobench,mfpbench,pymoo,yahpo
 ```
 
 All possible install options for optimizers are:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,39 @@
 # Installation
 
-To install CARP-S, you can use the following commands:
+### Installation from PyPI
+
+To install CARP-S, you can simply use `pip`:
+
+```bash
+conda create -n carps python=3.11
+conda activate carps
+pip install carps
+```
+
+Additionally, you need to install the requirements for the benchmark and optimizer that you want to use.
+For example, if you want to use the `SMAC2.0` optimizer and the `BBOB` benchmark, you need to install the
+requirements for both of them via:
+
+```bash
+pip install carps[smac,bbob]
+```
+
+All possible install options for benchmarks are:
+```bash
+dummy,bhob,hpob,hpobench,mfpbench,pymoo,yahpoo
+```
+
+All possible install options for optimizers are:
+```bash
+dummy,dehb,hebo,nevergrad,optuna,skopt,smac,smac14,synetune
+```
+
+Please note that installing all requirements for all benchmarks and optimizers in a single 
+environment will not be possible due to conflicting dependencies.
+
+### Installation from Source
+
+If you want to install from source, you can clone the repository and install CARP-S via:
 
 ```bash
 git clone https://github.com/AutoML/CARP-S.git
@@ -12,20 +45,17 @@ conda activate carps
 pip install .
 ```
 
+For installing the requirements for the optimizer and benchmark, you can then use the following command:
+```bash
+pip install ".[smac,bbob]"
+```
+
 If you want to install CARP-S for development, you can use the following command:
 ```bash
-# Install for development
 make install-dev
 ```
 
-Additionally, you need to install the requirements for the benchmark and optimizer that you 
-want to use. For example, if you want to use the `SMAC2.0` optimizer and the `BBOB` benchmark, 
-you need to install the requirements for both of them via:
-
-```bash
-pip install -r container_recipes/optimizers/SMAC3/SMAC3_requirements.txt
-pip install -r container_recipes/benchmarks/BBOB/BBOB_requirements.txt
-```
+### Additional Data Downloads
 
 For some benchmarks, it is additionally necessary to download data, 
 such as surrogate models, in order to run the benchmark: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,14 +81,12 @@ dummy = ["scikit-learn"]
 bbob = ["ioh==0.3.14"]
 hpob = ["xgboost==1.5.2"]
 hpobench = [
-  "hpobench@git+https://github.com/automl/HPOBench.git",
   "tqdm",
   "pandas==1.2.4",
   "Cython==0.29.36",
-  "scikit-learn==0.24.2", #--no-build-isolation
   "openml==0.12.2",
   "xgboost==1.3.1",
-  "ConfigSpace==0.6.1",
+  "ConfigSpace",
 ]
 mfpbench = [
   "scikit-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,14 +80,6 @@ dev = [
 dummy = ["scikit-learn"]
 bbob = ["ioh==0.3.14"]
 hpob = ["xgboost==1.5.2"]
-hpobench = [
-  "tqdm",
-  "pandas==1.2.4",
-  "Cython==0.29.36",
-  "openml==0.12.2",
-  "xgboost==1.3.1",
-  "ConfigSpace",
-]
 mfpbench = [
   "scikit-learn",
   "mf-prior-bench",


### PR DESCRIPTION
- fix typos
- consistent install instructions in readme & docs
- update instructions for installation hpobench (not possible directly via pyproject.toml)