### PR TITLE
Fix HPOBench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.1.2
 
 ## Benchmarks
-- HPOBench: Add rl, nasbench_101, nasbench_201, nasbench1shot1, and nas_hpo
+- HPOBench: Add rl, nasbench_101, nasbench_201, nasbench1shot1, and nas_hpo (#155, fix for benchmarks #158)
 
 # v0.1.1
 

--- a/carps/benchmarks/hpo_bench.py
+++ b/carps/benchmarks/hpo_bench.py
@@ -9,7 +9,7 @@ from hpobench.container.benchmarks.ml.lr_benchmark import LRBenchmark
 from hpobench.container.benchmarks.ml.nn_benchmark import NNBenchmark
 from hpobench.container.benchmarks.ml.rf_benchmark import RandomForestBenchmark
 from hpobench.container.benchmarks.ml.svm_benchmark import SVMBenchmark
-from hpobench.container.benchmarks.ml.tabular_benchmark import TabularBenchmark
+from hpobench.benchmarks.ml.tabular_benchmark import TabularBenchmark
 from hpobench.container.benchmarks.ml.xgboost_benchmark import XGBoostBenchmark
 from omegaconf import ListConfig
 

--- a/container_recipes/benchmarks/HPOBench/README.md
+++ b/container_recipes/benchmarks/HPOBench/README.md
@@ -4,3 +4,7 @@ a recipe for it (old package versions are fixed if wanting to run HPOBench local
 python version etc. in the main carp-s environment/ container if this would be done. They cannot be increased easily
 since old pickled surrogates need to be loaded in that environment in many cases). 
 
+## Troubleshooting
+If a container does not work,
+- make sure singularity is available, especially if you are on a cluster (e.g. `ml system singularity`)
+- it often helps to remove the container from the cache dir, e.g. `/home/username/.cache/hpobench/`.

--- a/container_recipes/benchmarks/HPOBench/install_HPOBench.sh
+++ b/container_recipes/benchmarks/HPOBench/install_HPOBench.sh
@@ -9,3 +9,4 @@ else
 fi
 $CONDA_RUN_COMMAND pip install git+https://github.com/automl/HPOBench.git@fix/numpy_deprecation
 $CONDA_RUN_COMMAND pip install ConfigSpace --upgrade
+$CONDA_RUN_COMMAND python container_recipes/benchmarks/HPOBench/prepare_nas_benchmarks.py

--- a/container_recipes/benchmarks/HPOBench/prepare_nas_benchmarks.py
+++ b/container_recipes/benchmarks/HPOBench/prepare_nas_benchmarks.py
@@ -1,0 +1,14 @@
+from hpobench.benchmarks.nas.nasbench_201 import NASBench_201Data
+# from hpobench.benchmarks.nas.nasbench_101 import NASBench_101DataManager
+
+# Load nasbench201 data
+datasets = ["cifar10-valid", "cifar100", "ImageNet16-120"]
+for dataset in datasets:
+    data_manager = NASBench_201Data(dataset=dataset)
+    data_manager.load()
+
+# # Load nasbench101 data
+# datasets = ["cifar10-valid", "cifar100", "ImageNet16-120"]
+# for dataset in datasets:
+#     data_manager = NASBench_101DataManager(dataset=dataset)
+#     data_manager.load()


### PR DESCRIPTION
- update requirements (works with ConfigSpace 1.x) (as long deprecation code still works)
- Fix tabular benchmark not working (container version did not work, now using normal version)
- Fix NAS benchmark not working (could not download the datasets from within the NAS containers, created script to download it before that)